### PR TITLE
removed padding from header & navbar

### DIFF
--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -1,5 +1,12 @@
 body{
     background: #BDBDBD;
+    margin: 0px;
+}
+
+.no_padding{
+    padding-left: 0px;
+    padding-right: 0px;
+
 }
 .header-image{
     position: relative;

--- a/website/index.html
+++ b/website/index.html
@@ -17,7 +17,7 @@
 <body>
 
     <!-- Navigation -->
-    <div class="container-fluid">
+    <div class="container-fluid no_padding">
         <span require-file="./templates/navbar.html"></span>
         <!-- Full Width Image Header -->
         <span require-file="./templates/tagline.html"></span>


### PR DESCRIPTION
Couldn't figure out why container-fluid had default padding in the navbar & header; made a class to get around that. 